### PR TITLE
Option --output <file> fails with path.resolve

### DIFF
--- a/src/solpp.js
+++ b/src/solpp.js
@@ -33,7 +33,7 @@ function loadDefs(file) {
 program
 	.version(VERSION, '-v --version')
 	.arguments('<source-file>')
-	.option('-o, --output <file>', 'write output to a file (instead of stdout)', path.resolve)
+	.option('-o, --output <file>', 'write output to a file (instead of stdout)')
 	.option('--no-flatten', 'do not flatten (include) naked imports')
 	.option('--no-pp', 'disable the preprocessor (just flatten)')
 	.option('-D, --define <name>[=value]', 'define a preprocessor symbol (can be repeated)',
@@ -51,7 +51,7 @@ program
 		};
 		const output = await lib.processFile(file, opts);
 		if (this.output)
-			await fs.writeFile(this.output, output, 'utf-8');
+			await fs.writeFile(path.resolve(this.output), output, 'utf-8');
 		else
 			console.log(output);
 	});


### PR DESCRIPTION
Using the option `--output <file>` causes solpp to fail with the error:
```
The "path" argument must be of type string. Received type undefined
```

This happens because commander passes a second arg to `path.resolve()` of the default value for the option, which is undefined.