### PR TITLE
Use lodash's trimeEnd instead of String's one

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ function collapseEmptyLines(code) {
 	}
 	if (r.length > 0 && !_.last(r))
 		r.splice(r.length-1, 1);
-	return r.join('\n').trimEnd();
+	return _.trimEnd(r.join('\n'));
 }
 
 async function processCode(code, opts={}) {

--- a/test/generate.js
+++ b/test/generate.js
@@ -13,6 +13,6 @@ describe('solidity-oven', function() {
 	it('generates the reference output', async function() {
 		const ref = await fs.readFile(REFERENCE_FILE, 'utf-8');
 		const output = await lib.processFile(INPUT_FILE, OPTS);
-		assert.equal(output.trimEnd(), ref.trimEnd());
+		assert.equal(_.trimEnd(output), _.trimEnd(ref));
 	});
 });


### PR DESCRIPTION
Hi,

This is a small change to support node 8. There were a few uses of `String.prototype.trimEnd`, which isn't available in node 8.

There's a `semver-merge` test failing, so I'm not sure if it was enough.