### PR TITLE
Use semver.compare instead of semver.cmp

### DIFF
--- a/src/semver-merge.js
+++ b/src/semver-merge.js
@@ -22,5 +22,5 @@ module.exports = function(semvers) {
 	if (versions.length == 0)
 		throw new Error(`Cannot reconcile semvers: ${semvers.join(', ')}`);
 	// Return the maximum version left.
-	return versions.sort((a,b) => -sv.cmp(a, b))[0];
+	return versions.sort((a,b) => -sv.compare(a, b))[0];
 };

--- a/test/semver.js
+++ b/test/semver.js
@@ -20,4 +20,8 @@ describe('semver-merge', function() {
 		assert.equal(merge(['0.4', '0.4.24']), '0.4.24');
 		assert.equal(merge(['^0.4', '0.4.24']), '0.4.24');
 	});
+
+	it('Handles multiple ranges with the same base version', async function() {
+		assert.equal(merge(['=0.4.24', '>=0.4.24']), '0.4.24');
+	});
 });


### PR DESCRIPTION
The `cmp` function in semver expects an operand: `function cmp (a, op, b, loose)`, but it was being called with just two versions: `sv.cmp(a, b)`.

The `compare` function matches the expected signature and behavior: `function compare (a, b, loose)`.

In practice, this meant that the sorting at the end of `semver-merge` didn't work correctly. I ran into this when contracts had the same base version, but different range specifiers, eg.: `=0.4.24` and `>=0.4.24`.